### PR TITLE
Update media player attributes to support current playlist uri

### DIFF
--- a/custom_components/spotifyplus/media_player.py
+++ b/custom_components/spotifyplus/media_player.py
@@ -434,6 +434,12 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
         """ Track number of current playing media, music track only. """
         return self._attr_media_track
 
+    @property
+    def media_playlist_uri(self):
+        """ Uri of Playlist currently playing. """
+        if self._playlist is not None:
+            return self._playlist.Uri
+        return None
 
     @property
     def media_playlist(self):


### PR DESCRIPTION
I'm not sure if this is allowed or complies with home assistant's default media player attributes, but it would be super useful to be able to get the current playlist Uri to be able to seamlessly transfer playback to other speakers. 