### PR TITLE
fix media_player.search_media return value

### DIFF
--- a/custom_components/spotifyplus/search_media.py
+++ b/custom_components/spotifyplus/search_media.py
@@ -100,8 +100,8 @@ def search_media_node(
         _ProcessFoundItems(result, SpotifyMediaTypes.SHOW, searchResp.Shows.Items)
         _ProcessFoundItems(result, SpotifyMediaTypes.TRACK, searchResp.Tracks.Items)
 
-        # return search results.
-        return result
+        # return search results as SearchMedia object.
+        return SearchMedia(result=result)
 
     except Exception as ex:
             


### PR DESCRIPTION
You forgot to wrap the `search_media` result in a `SearchMedia` object. With this fix the `HassMediaSearchAndPlay` intent is now working flawlessly!

Thank you so much for your awesome work here!